### PR TITLE
#22 Allow horizontal and vertical padding to be set independently

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -29,6 +29,6 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
     implementation 'com.google.android.material:material:1.3.0'
-//    implementation project(":tooltip")
-    implementation 'com.github.jayrambhia:Tooltip:0.1.7-1'
+    implementation project(":tooltip")
+//    implementation 'com.github.jayrambhia:Tooltip:0.1.7-1'
 }

--- a/sample/src/main/java/com/fenchtose/tooltip_demo/MainActivity.java
+++ b/sample/src/main/java/com/fenchtose/tooltip_demo/MainActivity.java
@@ -64,7 +64,7 @@ public class MainActivity extends AppCompatActivity {
                 showTooltip(v, R.string.bottom_auto_adjust, Tooltip.BOTTOM, true,
                         TooltipAnimation.SCALE, false,
                         tooltipSize,
-                        ViewGroup.LayoutParams.WRAP_CONTENT);
+                        ViewGroup.LayoutParams.WRAP_CONTENT, 0, 0);
             }
         });
 
@@ -74,7 +74,7 @@ public class MainActivity extends AppCompatActivity {
                 showTooltip(v, R.string.bottom_no_auto_adjust, Tooltip.BOTTOM, false,
                         TooltipAnimation.SCALE, false,
                         tooltipSize,
-                        ViewGroup.LayoutParams.WRAP_CONTENT);
+                        ViewGroup.LayoutParams.WRAP_CONTENT, 0, 0);
             }
         });
 
@@ -84,7 +84,25 @@ public class MainActivity extends AppCompatActivity {
                 showTooltip(v, R.string.bottom, Tooltip.BOTTOM, false,
                         TooltipAnimation.SCALE, true,
                         tooltipSize,
-                        ViewGroup.LayoutParams.WRAP_CONTENT);
+                        ViewGroup.LayoutParams.WRAP_CONTENT, 0, 0);
+            }
+        });
+
+        findViewById(R.id.top_auto_adjust_padding_horizontal_only).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showTooltip(v, R.string.top_auto_adjust_padding_horizontal_only, Tooltip.TOP, true,
+                        TooltipAnimation.NONE, false, tooltipSize,
+                        ViewGroup.LayoutParams.WRAP_CONTENT, 48, 0);
+            }
+        });
+
+        findViewById(R.id.top_auto_adjust_padding_vertical_only).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showTooltip(v, R.string.top_auto_adjust_padding_vertical_only, Tooltip.TOP, true,
+                        TooltipAnimation.NONE, false, tooltipSize,
+                        ViewGroup.LayoutParams.WRAP_CONTENT, 0, 48);
             }
         });
 
@@ -93,7 +111,7 @@ public class MainActivity extends AppCompatActivity {
             public void onClick(View v) {
                 showTooltip(v, R.string.top_auto_adjust, Tooltip.TOP, true,
                         TooltipAnimation.NONE, false, tooltipSize,
-                        ViewGroup.LayoutParams.WRAP_CONTENT);
+                        ViewGroup.LayoutParams.WRAP_CONTENT, 0, 0);
             }
         });
 
@@ -102,7 +120,7 @@ public class MainActivity extends AppCompatActivity {
             public void onClick(View v) {
                 showTooltip(v, R.string.top_no_auto_adjust, Tooltip.TOP, false,
                         TooltipAnimation.NONE, false, tooltipSize,
-                        ViewGroup.LayoutParams.WRAP_CONTENT);
+                        ViewGroup.LayoutParams.WRAP_CONTENT, 0, 0);
             }
         });
 
@@ -110,7 +128,7 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 showTooltip(v, R.string.top, Tooltip.TOP, false,TooltipAnimation.NONE, false, tooltipSize,
-                        ViewGroup.LayoutParams.WRAP_CONTENT);
+                        ViewGroup.LayoutParams.WRAP_CONTENT, 0, 0);
             }
         });
 
@@ -120,7 +138,7 @@ public class MainActivity extends AppCompatActivity {
                 showTooltip(v, R.string.right_auto_adjust, Tooltip.RIGHT, true,
                         TooltipAnimation.REVEAL, true,
                         ViewGroup.LayoutParams.WRAP_CONTENT,
-                        tooltipSize);
+                        tooltipSize, 0, 0);
             }
         });
 
@@ -130,7 +148,7 @@ public class MainActivity extends AppCompatActivity {
                 showTooltip(v, R.string.right_no_auto_adjust, Tooltip.RIGHT, false,
                         TooltipAnimation.REVEAL, true,
                         ViewGroup.LayoutParams.WRAP_CONTENT,
-                        tooltipSize);
+                        tooltipSize, 0, 0);
             }
         });
 
@@ -139,7 +157,7 @@ public class MainActivity extends AppCompatActivity {
             public void onClick(View v) {
                 showTooltip(v, R.string.right, Tooltip.RIGHT, false,
                         TooltipAnimation.REVEAL, false,
-                        tooltipSize, ViewGroup.LayoutParams.WRAP_CONTENT);
+                        tooltipSize, ViewGroup.LayoutParams.WRAP_CONTENT, 0, 0);
             }
         });
 
@@ -149,7 +167,7 @@ public class MainActivity extends AppCompatActivity {
                 showTooltip(v, R.string.left_auto_adjust, Tooltip.LEFT, true,
                         TooltipAnimation.SCALE_AND_FADE, true,
                         ViewGroup.LayoutParams.WRAP_CONTENT,
-                        tooltipSize);
+                        tooltipSize, 0, 0);
             }
         });
 
@@ -159,7 +177,7 @@ public class MainActivity extends AppCompatActivity {
                 showTooltip(v, R.string.left_no_auto_adjust, Tooltip.LEFT, false,
                         TooltipAnimation.SCALE_AND_FADE, true,
                         ViewGroup.LayoutParams.WRAP_CONTENT,
-                        tooltipSize);
+                        tooltipSize, 0, 0);
             }
         });
 
@@ -168,7 +186,7 @@ public class MainActivity extends AppCompatActivity {
             public void onClick(View v) {
                 showTooltip(v, R.string.left, Tooltip.LEFT, false,
                         TooltipAnimation.SCALE_AND_FADE, false,
-                        tooltipSize, ViewGroup.LayoutParams.WRAP_CONTENT);
+                        tooltipSize, ViewGroup.LayoutParams.WRAP_CONTENT, 0, 0);
             }
         });
     }
@@ -204,24 +222,36 @@ public class MainActivity extends AppCompatActivity {
     private void showTooltip(@NonNull View anchor, @StringRes int resId,
                              @Tooltip.Position int position, boolean autoAdjust,
                              @TooltipAnimation.Type int type, boolean hideWhenAnimating,
-                             int width, int height) {
+                             int width, int height, int paddingHorizontal, int paddingVertical) {
         ViewGroup contentView = (ViewGroup) getLayoutInflater().inflate(R.layout.tooltip_textview, null);
         TextView textView = (TextView) contentView.getChildAt(0);
         textView.setText(resId);
         textView.setLayoutParams(new FrameLayout.LayoutParams(width, height));
-        showTooltip(anchor, contentView, position, autoAdjust, type, hideWhenAnimating, tooltipColor);
+        showTooltip(
+                anchor,
+                contentView,
+                position,
+                autoAdjust,
+                type,
+                hideWhenAnimating,
+                tooltipColor,
+                paddingHorizontal,
+                paddingVertical
+        );
     }
 
     private void showTooltip(@NonNull View anchor, @NonNull View content,
                              @Tooltip.Position int position, boolean autoAdjust,
                              @TooltipAnimation.Type int type, boolean hideWhenAnimating,
-                             int tipColor) {
+                             int tipColor, int paddingHorizontal, int paddingVertical) {
 
         new Tooltip.Builder(this)
                 .anchor(anchor, position)
                 .animate(new TooltipAnimation(type, 500, hideWhenAnimating))
                 .autoAdjust(autoAdjust)
                 .content(content)
+                .withPaddingHorizontal(paddingHorizontal)
+                .withPaddingVertical(paddingVertical)
                 .withTip(new Tooltip.Tip(tipSizeRegular, tipSizeRegular, tipColor))
                 .into(root)
                 .debug(true)

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -29,6 +29,22 @@
 
     <ImageView
         android:layout_alignParentBottom="true"
+        android:id="@+id/top_auto_adjust_padding_horizontal_only"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="96dp"
+        android:src="@mipmap/ic_launcher"/>
+
+    <ImageView
+        android:layout_alignParentBottom="true"
+        android:id="@+id/top_auto_adjust_padding_vertical_only"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="48dp"
+        android:src="@mipmap/ic_launcher"/>
+
+    <ImageView
+        android:layout_alignParentBottom="true"
         android:id="@+id/top_auto_adjust"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="bottom_no_auto_adjust">This tooltip has BOTTOM position. It will not auto adjust to bounds. SCALE Animation</string>
     <string name="bottom">This tooltip has BOTTOM position and no adjustments are required. SCALE Animation</string>
 
+    <string name="top_auto_adjust_padding_horizontal_only">This tooltip has TOP position and it will adjust its sides so as to stay in the bounds. It has horizontal padding with no vertical padding. NO animation</string>
+    <string name="top_auto_adjust_padding_vertical_only">This tooltip has TOP position and it will adjust its sides so as to stay in the bounds. It has vertical padding with no horizontal padding. NO animation</string>
     <string name="top_auto_adjust">This tooltip has TOP position and it will adjust its sides so as to stay in the bounds. NO animation</string>
     <string name="top_no_auto_adjust">This tooltip has TOP position. It will not auto adjust to bounds. NO animation</string>
     <string name="top">This tooltip has TOP position and no adjustments are required. NO animation</string>

--- a/tooltip/src/main/java/com/fenchtose/tooltip/Tooltip.java
+++ b/tooltip/src/main/java/com/fenchtose/tooltip/Tooltip.java
@@ -52,7 +52,8 @@ public class Tooltip extends ViewGroup {
     private boolean isCancelable = true;
     private boolean autoAdjust = true;
 
-    private int padding;
+    private int paddingHorizontal;
+    private int paddingVertical;
 
     private Listener builderListener;
     private Listener listener;
@@ -112,7 +113,8 @@ public class Tooltip extends ViewGroup {
 
         this.autoAdjust = builder.autoAdjust;
         this.position = builder.position;
-        this.padding = builder.padding;
+        this.paddingHorizontal = builder.paddingHorizontal;
+        this.paddingVertical = builder.paddingVertical;
         this.checkForPreDraw = builder.checkForPreDraw;
         this.debug = builder.debug;
 
@@ -253,7 +255,7 @@ public class Tooltip extends ViewGroup {
 
                 int diff = (anchorView.getHeight() - h) / 2;
                 // We should pad right side
-                left -= (w + padding + (showTip ? tip.getHeight() : 0));
+                left -= (w + paddingHorizontal + (showTip ? tip.getHeight() : 0));
                 // Top and bottom padding is not required
                 top += diff;
 
@@ -274,7 +276,7 @@ public class Tooltip extends ViewGroup {
                 // align with horizontal axis
                 int diff = (anchorView.getHeight() - h) / 2;
                 // We should pad left side
-                left += (anchorView.getWidth() + padding + (showTip ? tip.getHeight() : 0));
+                left += (anchorView.getWidth() + paddingHorizontal + (showTip ? tip.getHeight() : 0));
                 // Top and bottom padding is not required
                 top += diff;
 
@@ -299,7 +301,7 @@ public class Tooltip extends ViewGroup {
                 left += diff;
 
                 // We should only pad bottom
-                top -= (h + padding + (showTip ? tip.getHeight() : 0));
+                top -= (h + paddingVertical + (showTip ? tip.getHeight() : 0));
 
                 if (showTip) {
                     px = left + w / 2;
@@ -322,7 +324,7 @@ public class Tooltip extends ViewGroup {
                 left += diff;
 
                 // We should only pad top
-                top += anchorView.getHeight() + padding + (showTip ? tip.getHeight() : 0);
+                top += anchorView.getHeight() + paddingVertical + (showTip ? tip.getHeight() : 0);
 
                 if (debug) {
                     Log.d(TAG, "tip top: " + top);
@@ -350,11 +352,11 @@ public class Tooltip extends ViewGroup {
                     if (left + w > r) {
                         // View is going out on the right side
                         // Add padding to the right
-                        left = r - w - padding;
+                        left = r - w - paddingHorizontal;
                     } else if (left < l) {
                         // View is going out on the left side
                         // Add padding to the left
-                        left = l + padding;
+                        left = l + paddingHorizontal;
                     }
                     break;
 
@@ -363,11 +365,11 @@ public class Tooltip extends ViewGroup {
                     if (top + h > b) {
                         // View is going out on the bottom side
                         // Add padding to bottom
-                        top = b - h - padding;
+                        top = b - h - paddingVertical;
                     } else if (top < t) {
                         // View is going out on the top side
                         // Add padding to top
-                        top = t + padding;
+                        top = t + paddingVertical;
                     }
                     break;
             }
@@ -702,10 +704,9 @@ public class Tooltip extends ViewGroup {
          */
         private Tip tip;
 
-        /**
-         * Margin from the anchor and screen boundaries
-         */
-        private int padding = 0;
+        private int paddingHorizontal = 0;
+
+        private int paddingVertical = 0;
 
         /**
          * If you want the tooltip to dismiss automatically after a certain amount of time,
@@ -840,7 +841,18 @@ public class Tooltip extends ViewGroup {
          * @return Builder
          */
         public Builder withPadding(int padding) {
-            this.padding = padding;
+            this.paddingHorizontal = padding;
+            this.paddingVertical = padding;
+            return this;
+        }
+
+        public Builder withPaddingHorizontal(int paddingHorizontal) {
+            this.paddingHorizontal = paddingHorizontal;
+            return this;
+        }
+
+        public Builder withPaddingVertical(int paddingVertical) {
+            this.paddingVertical = paddingVertical;
             return this;
         }
 


### PR DESCRIPTION
### Background

The margin from the coachmark to its anchor and the screen edge is currently set by a single integer value. This failed my use-case of a TOP or BOTTOM coachmark that should be a certain distance horizontally from the screen-edge, but very close to its anchoring view.

### Changes

This commit introduces two new `Builder` functions: `withPaddingHorizontal` and `withPaddingVertical`.

The private parameter `padding` has been split into `paddingHorizontal` and `paddingVertical` and these functions set the respective value.

The existing `Builder` function `withPadding` sets both `paddingHorizontal` and `paddingVertical` and is unchanged.